### PR TITLE
Update datasource-checker.json

### DIFF
--- a/applications/grafana/chart/config/dashboards/datasource-checker.json
+++ b/applications/grafana/chart/config/dashboards/datasource-checker.json
@@ -101,7 +101,7 @@
             "hide": false,
             "metricColumn": "none",
             "rawQuery": true,
-            "rawSql": "SELECT *\nFROM mttest.etairqualityobserved\n\n",
+            "rawSql": "SELECT *\nFROM etairqualityobserved\n\n",
             "refId": "B",
             "select": [
             [


### PR DESCRIPTION
Quantum leap stores data in etairqualityobserved instead of mttest.etairqualityobserved
See:
```shell
       table_name       |                                                                                      entity_attrs                                                                                      
------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 "mttest"."ettest"      | {"test": ["test", "Number"], "entity_id": ["id", "Text"], "time_index": ["time_index", "DateTime"], "entity_type": ["type", "Text"]}
 "etairqualityobserved" | {"humidity": ["humidity", "Number"], "entity_id": ["id", "Text"], "time_index": ["time_index", "DateTime"], "entity_type": ["type", "Text"], "temperature": ["temperature", "Number"]}

```