### PR TITLE
Add actions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Demo deployment](https://github.com/FIWARE-Ops/marinera/actions/workflows/deploy.yaml/badge.svg)
+
 # FIWARE Platform Deployment
 
 


### PR DESCRIPTION
Add actions badge to README to have a radiator that shows how the GH action to deploy to demo is going