### PR TITLE
Update values.yaml

### DIFF
--- a/applications/grafana/chart/values.yaml
+++ b/applications/grafana/chart/values.yaml
@@ -36,7 +36,11 @@ grafana:
       labelValue: grafana
       orgid: 1
       defaultFolderName: default
-  
+    datasources:
+      enabled: true
+      label: grafana_datasource
+      labelValue: grafana
+      
   dashboardProviders:
     dashboardproviders.yaml:
       apiVersion: 1
@@ -58,10 +62,7 @@ grafana:
         options:
           path: /tmp/dashboards/air-quality  # should match sidecar.dashboards.defaultFolderName
     
-    datasources:
-      enabled: true
-      label: grafana_datasource
-      labelValue: grafana
+
   podLabels:
     marinera/platform: fiware
     marinera/component:	visualization


### PR DESCRIPTION
Changing the order of the values did move the datasources to the dashboardProviders(thus being ignored), instead of to the sidecar, that is responsible for deploying them.
The order change moves that back.