### PR TITLE
Computate mongodb

### DIFF
--- a/applications/mongodb/chart/Chart.yaml
+++ b/applications/mongodb/chart/Chart.yaml
@@ -8,7 +8,7 @@ appVersion: "4.4.12" # MongoDB version 4.4.12
 
 dependencies:
 - name: mongodb
-  version: 11.0.4
+  version: 12.1.31
   repository: https://charts.bitnami.com/bitnami
 
 maintainers:

--- a/kustomize/bundles/argocd/base/argocds/argocd/argocd.yaml
+++ b/kustomize/bundles/argocd/base/argocds/argocd/argocd.yaml
@@ -42,6 +42,11 @@ spec:
   initialSSHKnownHosts: {}
   rbac:
     policy: |
+      p, role:admin, applications, sync, */*, allow
+      p, role:admin, applications, update, */*, allow
+      p, role:admin, applications, delete, */*, allow
+
+      g, system:authenticated, role:admin
       g, system:cluster-admins, role:admin
       g, cluster-admins, role:admin
       g, ArgoCDAdmins, role:admin


### PR DESCRIPTION
Hello @wistefan , 

Happy New Year FIWARE! I wish you the best this new year. I wanted to share a pull request. I found that deploying mongodb Helm Chart version 11.0.4 from bitnami no longer works. It's been deleted. Here is an update for that. 

Updating mongodb to Helm Chart version from 11.0.4 to 12.1.31

The 11.0.4 Helm Chart for mongodb provided by bitnami no longer exists.
This upgrades the mongodb Helm Chart to version 12.1.31.

Also allow authenticated users to sync, update, and delete ArgoCD applications. 